### PR TITLE
fix tests since /data might exist in CI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,23 @@ def job_manifest_simple_path(job_manifest_simple, tmpdir):
 
 
 @pytest.fixture
+def job_manifest_unknown_data(tasks_fixtures_path):
+    return dedent(
+        f"""
+        name: Simple job manifest
+        data: /not/a/path/that/should/exist/on/any/system
+        tasks: {tasks_fixtures_path}
+        commands: []
+        """
+    )
+
+
+@pytest.fixture
+def job_manifest_unknown_data_path(job_manifest_unknown_data, tmpdir):
+    return job_file(job_manifest_unknown_data, tmpdir)
+
+
+@pytest.fixture
 def job_manifest_multiple_commands(tasks_fixtures_path):
     return dedent(
         f"""

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -74,9 +74,10 @@ def test_execute_job_stops_if_command_fails(
 
 
 @pytest.mark.real_verify_data_dir
-def test_execute_job_fails_if_data_dir_does_not_exist(job_manifest_simple_path):
+@mock.patch("xetl.models.task.Task.execute", mock.Mock(side_effect=Exception("Task should not have been executed")))
+def test_execute_job_fails_if_data_dir_does_not_exist(job_manifest_unknown_data_path):
     with pytest.raises(JobDataDirectoryNotFound):
-        engine.execute_job(job_manifest_simple_path)
+        engine.execute_job(job_manifest_unknown_data_path)
 
 
 @pytest.mark.real_verify_data_dir


### PR DESCRIPTION
The test fixture assumed the path `/data` would not exist but I guess it does exist in CI..